### PR TITLE
Store and display the talk length from the pybay proposals api.

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -185,6 +185,7 @@ def add_proposal(data):
             "category",
             "what_will_attendees_learn",
             "speaker_and_talk_history",
+            "talk_length",
             )
 
     cleaned_data = {k:data[k] for k in keys}

--- a/templates/proposal_render.html
+++ b/templates/proposal_render.html
@@ -53,6 +53,10 @@
         <p>
         {{version.what_will_attendees_learn}}
         </p>
+        <h3>Talk length</h3>
+        <p>
+        {{version.talk_length}}    
+        </p>
         {% if not anonymize %}
         <h3>Speaker and talk history</h3>
         <p>


### PR DESCRIPTION
Store the 'talk_length' from the proposal details when pull_updates.py syncs proposals from pybay, and display it in Progcom.